### PR TITLE
Feature/request logging

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,18 @@
+{
+    "indent_size": 4,
+    "indent_char": " ",
+    "indent_level": 0,
+    "indent_with_tabs": false,
+    "preserve_newlines": true,
+    "max_preserve_newlines": 10,
+    "jslint_happy": false,
+    "brace_style": "end-expand",
+    "keep_array_indentation": false,
+    "keep_function_indentation": false,
+    "space_in_paren": true,
+    "space_before_conditional": true,
+    "break_chained_methods": false,
+    "eval_code": false,
+    "unescape_strings": false,
+    "wrap_line_length": 0
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+    "node": true,
+    "undef": true,
+    "unused": true,
+    "esnext": true,
+    "predef": [ "require", "module" ],
+    "globalstrict": true,
+    "trailing": true,
+    "-W097": true,
+    "quotmark": "single"
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you don't already have an express app, you can tell storehouse to listen on i
 
 ```javascript
 storehouse.listen({
-    port: 8888 
+    port: 8888
 });
 ```
 
@@ -120,15 +120,15 @@ ajaxCall({
     success: function( signature ) {
         // here your API has given us back a signature that allows this file to be uploaded,
         // now we can send the file to the server
-        
+
         var formData = new FormData();
 
         formData.append( 'path', path );
         formData.append( 'signature', signature );
         formData.append( 'file', file ); // this would be from a file input in a form, for example
-     
+
         var xhr = new XMLHttpRequest();
-        
+
         xhr.onreadystatechange = function() {
             if ( xhr.readyState == 4 ) // complete
             {
@@ -138,7 +138,7 @@ ajaxCall({
                 }
             }
         }
-     
+
         xhr.upload.addEventListener( 'progress', function( progressEvent ) {
             if ( progressEvent.lengthComputable )
             {
@@ -146,19 +146,19 @@ ajaxCall({
                 console.log( percentComplete ); // let's print the progress of our upload to the console
             }
         }, false);
-         
+
         xhr.addEventListener( 'load', function() {
             alert( 'Done!' );
         }, false );
-         
+
         xhr.addEventListener( 'error', function( error ) {
            alert( error );
         }, false );
-        
+
         xhr.addEventListener( 'abort', function() {
            alert( 'Aborted!' );
         }, false );
-    
+
         xhr.open( 'POST', '/fileupload', true ); // open a post to whatever URL you've configured Storehouse to listen to
         xhr.send( formData ); // send the file
     }
@@ -176,6 +176,13 @@ Check out this great post by Vikrum Nijjar about switching from S3 to Fastly: ht
 That post started me down this road. Except I needed a way for users to upload things to my server that I could then allow Fastly to cache. Hence: Storehouse.
 
 # CHANGELOG
+
+v0.0.7
+------
+- Improved logging
+  - fetch- and upload-requests are now logged
+  - file mime type added to logging output
+  - file encoding added to logging output
 
 v0.0.6
 ------

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ If you're already using express, you can attach a storehouse directly to your ap
 ```javascript
 var Storehouse = require( 'storehouse' );
 
-var storehouse = new Storehouse({
+var storehouse = new Storehouse( {
     url: '/fileupload',
     directory: './files',
     allowDownload: true,
     downloadPrefix: '/files',
     secret: 'this is the secret key'
-});
+} );
 
 storehouse.attach( app ); // attach to an existing express app
 ```
@@ -42,22 +42,22 @@ storehouse.attach( app ); // attach to an existing express app
 If you don't already have an express app, you can tell storehouse to listen on its own:
 
 ```javascript
-storehouse.listen({
+storehouse.listen( {
     port: 8888
-});
+} );
 ```
 
 Storehouse also supports SSL:
 
 ```javascript
-storehouse.listen({
+storehouse.listen( {
     port: 8888,
     ssl: {
         key: './path/to/ssl.key',
         cert: './path/to/ssl.crt',
         port: 4443
     }
-});
+} );
 ```
 
 ### As a standalone server:
@@ -110,7 +110,7 @@ Good question! Storehouse is mostly intended to be used as a part of an existing
 In that service, you should expose a way for a user to obtain a signature for a file they'd like to upload. In that case, you can verify they have permission to upload and you can keep your secret key secret. Here's an example of how you might usually handle a file upload in this way:
 
 ```javascript
-ajaxCall({
+ajaxCall( {
     url: '/api/fileuploadsignature',
     type: 'POST',
     data: {
@@ -132,42 +132,40 @@ ajaxCall({
         xhr.onreadystatechange = function() {
             if ( xhr.readyState == 4 ) // complete
             {
-                if ( xhr.status < 200 || xhr.status >= 400 )
-                {
+                if ( xhr.status < 200 || xhr.status >= 400 ) {
                     alert( xhr.responseText ); // oops, error!
                 }
             }
         }
 
         xhr.upload.addEventListener( 'progress', function( progressEvent ) {
-            if ( progressEvent.lengthComputable )
-            {
+            if ( progressEvent.lengthComputable ) {
                 var percentComplete = Math.floor( ( progressEvent.loaded / progressEvent.total ) * 100 );
                 console.log( percentComplete ); // let's print the progress of our upload to the console
             }
-        }, false);
+        }, false );
 
         xhr.addEventListener( 'load', function() {
             alert( 'Done!' );
         }, false );
 
         xhr.addEventListener( 'error', function( error ) {
-           alert( error );
+            alert( error );
         }, false );
 
         xhr.addEventListener( 'abort', function() {
-           alert( 'Aborted!' );
+            alert( 'Aborted!' );
         }, false );
 
         xhr.open( 'POST', '/fileupload', true ); // open a post to whatever URL you've configured Storehouse to listen to
         xhr.send( formData ); // send the file
     }
-});
+} );
 ```
 
 ## Why?
 
-I created this because I became fustrated working with Amazon S3/CloudFront. Don't get me wrong, S3/CloudFront is great: tough to beat on price and there's no question of it handling scaling.
+I created this because I became frustrated working with Amazon S3/CloudFront. Don't get me wrong, S3/CloudFront is great: tough to beat on price and there's no question of it handling scaling.
 
 So why was I frustrated? Because I am often a 1-man team. Amazon AWS services are great, but they're really meant for larger-scale operations. Sometimes you just need to upload some files and not have to try to figure out all the nooks and crannies that AWS provides for managing a huge enterprise. And Amazon's approach is essentially that you write your own tooling.
 
@@ -183,6 +181,7 @@ v0.0.7
   - fetch- and upload-requests are now logged
   - file mime type added to logging output
   - file encoding added to logging output
+- Added .jsbeautifyrc and .jshintrc files to project
 
 v0.0.6
 ------
@@ -192,7 +191,7 @@ v0.0.5
 ------
 - CORS fixes
   - reflect back access-control-request-headers
-  - allow restricing the CORS origin with an option
+  - allow restricting the CORS origin with an option
 
 v0.0.4
 ------

--- a/cli.js
+++ b/cli.js
@@ -44,7 +44,7 @@ var options = {
 
 var listenOptions = {
     ssl: {}
-}
+};
 
 if ( program.uploadurl )     options.uploadurl = program.uploadurl;
 if ( program.fetchurl )      options.fetchurl = program.fetchurl;
@@ -65,11 +65,11 @@ if ( !program.quiet )
     console.log( '*** Storehouse started ( ' + humanize.date( 'c' ) + ' )' );
 
     storehouse.on( 'upload-requested', function( event ) {
-        console.log( humanize.date( 'c' ) + ' upload REQUESTED: ' + event.path + ' (' + event.location + ')' );
+        console.log( humanize.date( 'c' ) + ' upload REQUESTED: ' + event.path + ' (' + event.location + ') ' + event.type + ' (encoding: ' + event.encoding + ')');
     } );
 
     storehouse.on( 'uploaded', function( event ) {
-        console.log( humanize.date( 'c' ) + ' uploaded: ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) );
+        console.log( humanize.date( 'c' ) + ' uploaded: ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) + ' ' + event.type + ' (encoding: ' + event.encoding + ')');
     } );
 
     storehouse.on( 'fetch-requested', function( event ) {
@@ -77,6 +77,6 @@ if ( !program.quiet )
     } );
 
     storehouse.on( 'fetched', function( event ) {
-        console.log( humanize.date( 'c' ) + ' fetched url "' + event.url + '": ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) );
+        console.log( humanize.date( 'c' ) + ' fetched url "' + event.url + '": ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) + ' ' + event.type );
     } );
 }

--- a/cli.js
+++ b/cli.js
@@ -63,7 +63,7 @@ var storehouse = new Storehouse( options ).listen( listenOptions );
 if ( !program.quiet )
 {
     console.log( "Storehouse started..." );
-    
+
     storehouse.on( 'uploaded', function( event ) {
         console.log( humanize.date( 'c' ) + ' uploaded: ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) );
     } );

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 var program = require( 'commander' );
 var humanize = require( 'humanize' );
 
@@ -21,16 +22,13 @@ program
     .option( '--quiet', 'Do not print out upload events.' )
     .parse( process.argv );
 
-if ( !program.secret )
-{
+if ( !program.secret ) {
     var fs = require( 'fs' );
-    if ( fs.existsSync( keyfilename ) )
-    {
+    if ( fs.existsSync( keyfilename ) ) {
         var keyfile_contents = fs.readFileSync( keyfilename, 'utf8' );
         program.secret = keyfile_contents.trim();
     }
-    else
-    {
+    else {
         program.help();
         process.exit( 1 );
     }
@@ -46,30 +44,29 @@ var listenOptions = {
     ssl: {}
 };
 
-if ( program.uploadurl )     options.uploadurl = program.uploadurl;
-if ( program.fetchurl )      options.fetchurl = program.fetchurl;
-if ( program.nooverwrite )   options.overwrite = false;
-if ( program.directory )     options.directory = program.directory;
+if ( program.uploadurl ) options.uploadurl = program.uploadurl;
+if ( program.fetchurl ) options.fetchurl = program.fetchurl;
+if ( program.nooverwrite ) options.overwrite = false;
+if ( program.directory ) options.directory = program.directory;
 if ( program.allowDownload ) options.allowDownload = true;
-if ( program.prefix )        options.downloadPrefix = program.prefix;
-if ( program.cors )          options.cors = true;
-if ( program.cors_origin )   options.origin = program.cors_origin;
-if ( program.port )          listenOptions.port = program.port;
-if ( program.sslkey )        listenOptions.ssl.key = program.sslkey;
-if ( program.sslcert )       listenOptions.ssl.cert = program.sslcert;
+if ( program.prefix ) options.downloadPrefix = program.prefix;
+if ( program.cors ) options.cors = true;
+if ( program.cors_origin ) options.origin = program.cors_origin;
+if ( program.port ) listenOptions.port = program.port;
+if ( program.sslkey ) listenOptions.ssl.key = program.sslkey;
+if ( program.sslcert ) listenOptions.ssl.cert = program.sslcert;
 
 var storehouse = new Storehouse( options ).listen( listenOptions );
 
-if ( !program.quiet )
-{
+if ( !program.quiet ) {
     console.log( '*** Storehouse started ( ' + humanize.date( 'c' ) + ' )' );
 
     storehouse.on( 'upload-requested', function( event ) {
-        console.log( humanize.date( 'c' ) + ' upload REQUESTED: ' + event.path + ' (' + event.location + ') ' + event.type + ' (encoding: ' + event.encoding + ')');
+        console.log( humanize.date( 'c' ) + ' upload REQUESTED: ' + event.path + ' (' + event.location + ') ' + event.type + ' (encoding: ' + event.encoding + ')' );
     } );
 
     storehouse.on( 'uploaded', function( event ) {
-        console.log( humanize.date( 'c' ) + ' uploaded: ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) + ' ' + event.type + ' (encoding: ' + event.encoding + ')');
+        console.log( humanize.date( 'c' ) + ' uploaded: ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) + ' ' + event.type + ' (encoding: ' + event.encoding + ')' );
     } );
 
     storehouse.on( 'fetch-requested', function( event ) {

--- a/cli.js
+++ b/cli.js
@@ -62,10 +62,18 @@ var storehouse = new Storehouse( options ).listen( listenOptions );
 
 if ( !program.quiet )
 {
-    console.log( "Storehouse started..." );
+    console.log( '*** Storehouse started ( ' + humanize.date( 'c' ) + ' )' );
+
+    storehouse.on( 'upload-requested', function( event ) {
+        console.log( humanize.date( 'c' ) + ' upload REQUESTED: ' + event.path + ' (' + event.location + ')' );
+    } );
 
     storehouse.on( 'uploaded', function( event ) {
         console.log( humanize.date( 'c' ) + ' uploaded: ' + event.path + ' (' + event.location + ') ' + humanize.filesize( event.size ) );
+    } );
+
+    storehouse.on( 'fetch-requested', function( event ) {
+        console.log( humanize.date( 'c' ) + ' url-fetch REQUESTED: "' + event.url + '": ' + event.path + ' (' + event.location + ')' );
     } );
 
     storehouse.on( 'fetched', function( event ) {

--- a/cli.js
+++ b/cli.js
@@ -44,17 +44,17 @@ var listenOptions = {
     ssl: {}
 };
 
-if ( program.uploadurl ) options.uploadurl = program.uploadurl;
-if ( program.fetchurl ) options.fetchurl = program.fetchurl;
-if ( program.nooverwrite ) options.overwrite = false;
-if ( program.directory ) options.directory = program.directory;
+if ( program.uploadurl )     options.uploadurl = program.uploadurl;
+if ( program.fetchurl )      options.fetchurl = program.fetchurl;
+if ( program.nooverwrite )   options.overwrite = false;
+if ( program.directory )     options.directory = program.directory;
 if ( program.allowDownload ) options.allowDownload = true;
-if ( program.prefix ) options.downloadPrefix = program.prefix;
-if ( program.cors ) options.cors = true;
-if ( program.cors_origin ) options.origin = program.cors_origin;
-if ( program.port ) listenOptions.port = program.port;
-if ( program.sslkey ) listenOptions.ssl.key = program.sslkey;
-if ( program.sslcert ) listenOptions.ssl.cert = program.sslcert;
+if ( program.prefix )        options.downloadPrefix = program.prefix;
+if ( program.cors )          options.cors = true;
+if ( program.cors_origin )   options.origin = program.cors_origin;
+if ( program.port )          listenOptions.port = program.port;
+if ( program.sslkey )        listenOptions.ssl.key = program.sslkey;
+if ( program.sslcert )       listenOptions.ssl.cert = program.sslcert;
 
 var storehouse = new Storehouse( options ).listen( listenOptions );
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "storehouse",
   "description": "Simple http file store in node.js",
   "author": "Andy Burke <aburke@bitflood.org>",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/andyburke/node-storehouse.git"

--- a/storehouse.js
+++ b/storehouse.js
@@ -94,20 +94,12 @@ Storehouse.prototype.attach = function( app ) {
         var filename = path.normalize( self.options.directory + path.sep + request.body.path );
         var directory = path.dirname( filename );
 
-        mimeMagic.detectFile( filename, function( mimeError, mimeType ) {
-            if ( mimeError )
-            {
-                console.error( mimeError );
-            }
-
-            self.emit( 'fetch-requested', {
-                url: request.body.url,
-                path: request.body.path,
-                directory: directory,
-                filename: filename,
-                location: path.resolve( filename ),
-                type: mimeType
-            } );
+        self.emit( 'fetch-requested', {
+            url: request.body.url,
+            path: request.body.path,
+            directory: directory,
+            filename: filename,
+            location: path.resolve( filename )
         } );
 
         self.Fetch( request, response, next );

--- a/storehouse.js
+++ b/storehouse.js
@@ -29,9 +29,9 @@ module.exports = Storehouse;
 function Storehouse( _options ) {
     var self = this;
     EventEmitter.call( self );
-    
+
     self.options = extend( {}, defaults, _options );
-    
+
     if ( !self.options.secret )
     {
         throw 'You must specify a secret.';
@@ -46,25 +46,25 @@ Storehouse.prototype.attach = function( app ) {
     if ( self.options.allowDownload )
     {
         var staticMiddleware = express.static( self.options.directory[ 0 ] == path.sep ? self.options.directory : ( process.cwd() + path.sep + self.options.directory ) );
-        
+
         app.use( self.options.downloadPrefix, staticMiddleware );
     }
-    
+
     function AllowCORS( request, response, next ) {
         response.header( 'Access-Control-Allow-Origin', self.options.origin );
         response.header( 'Access-Control-Allow-Methods', 'POST' );
-        
+
         if ( !!request.headers[ 'access-control-request-headers' ] )
         {
             response.header( 'Access-Control-Allow-Headers', request.headers[ 'access-control-request-headers' ] );
         }
-    
+
         if ( request.method === 'OPTIONS' )
         {
             response.send( 200 );
             return;
         }
-        
+
         next();
     }
 
@@ -73,7 +73,7 @@ Storehouse.prototype.attach = function( app ) {
         app.all( self.options.uploadURL, AllowCORS );
         app.all( self.options.fetchURL, AllowCORS );
     }
-    
+
     app.post( self.options.uploadURL, bodyParser(), multer(), function( request, response, next ) {
         self.AcceptUpload( request, response, next );
     } );
@@ -85,13 +85,13 @@ Storehouse.prototype.attach = function( app ) {
 
 Storehouse.prototype.AcceptUpload = function( request, response ) {
     var self = this;
-    
+
     if ( !request.files || !request.files[ 'file' ] )
     {
         response.json( { error: 'file missing', message: 'No file present in request.' }, 400 );
         return;
     }
-    
+
     if ( !request.body.path )
     {
         response.json( { error: 'path missing', message: 'No path specified in request.' }, 400 );
@@ -103,10 +103,10 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
         response.json( { error: 'signature missing', message: 'No signature specified in request.' }, 400 );
         return;
     }
-    
+
     var fileInfo = request.files[ 'file' ];
     var signature = crypto.createHash( 'sha1' ).update( request.body.path + fileInfo.mimetype + self.options.secret ).digest( 'hex' );
-    
+
     if ( signature != request.body.signature )
     {
         response.json( { error: 'invalid signature', message: 'Signature for this upload is invalid.' }, 400 );
@@ -115,7 +115,7 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
 
     var filename = path.normalize( self.options.directory + path.sep + request.body.path );
     var directory = path.dirname( filename );
-    
+
     async.series( [
         // check if the file exists and if we can overwrite it if it does
         function( callback ) {
@@ -125,11 +125,11 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
                     callback( { error: 'file exists', message: 'The file you are trying to upload already exists and cannot be overwritten.', code: 400 } );
                     return;
                 }
-            
+
                 callback();
             } );
         },
-        
+
         // create the necessary directory structure
         function( callback ) {
             fs.mkdir( directory, '0755', true, function( error ) {
@@ -138,11 +138,11 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
                     callback( { error: 'error creating directory', message: error, code: 500 } );
                     return;
                 }
-            
+
                 callback();
             } );
         },
-        
+
         // move the uploaded file from its temp location to the target location
         function( callback ) {
             fs.rename( fileInfo.path, filename, function( error ) {
@@ -151,11 +151,11 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
                     callback( { error: 'error moving file', message: error, code: 500 } );
                     return;
                 }
-            
+
                 callback();
             } );
         },
-        
+
         // set proper permissions on the uploaded file
         function( callback ) {
             fs.chmod( filename, '0644', function( error ) {
@@ -164,18 +164,18 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
                     callback( { error: 'error changing file permissions', message: error, code: 500 } );
                     return;
                 }
-            
+
                 callback();
             } );
         }
-        
+
     ], function( error ) {
         if ( error )
         {
             response.json( error, error.code || 500 );
             return;
         }
-        
+
         response.json( { 'path': request.body.path } );
 
         fs.stat( filename, function( error, stats ) {
@@ -183,7 +183,7 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
             {
                 console.error( error );
             }
-            
+
             self.emit( 'uploaded', {
                 path: request.body.path,
                 directory: directory,
@@ -198,13 +198,13 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
 
 Storehouse.prototype.Fetch = function( request, response ) {
     var self = this;
-    
+
     if ( !request.body.url )
     {
         response.json( { error: 'url missing', message: 'No url to fetch specified in request.' }, 400 );
         return;
     }
-    
+
     if ( !request.body.path )
     {
         response.json( { error: 'path missing', message: 'No path specified in request.' }, 400 );
@@ -216,9 +216,9 @@ Storehouse.prototype.Fetch = function( request, response ) {
         response.json( { error: 'signature missing', message: 'No signature specified in request.' }, 400 );
         return;
     }
-    
+
     var signature = crypto.createHash( 'sha1' ).update( request.body.url + request.body.path + self.options.secret ).digest( 'hex' );
-    
+
     if ( signature != request.body.signature )
     {
         response.json( { error: 'invalid signature', message: 'Signature for this fetch request is invalid.' }, 400 );
@@ -227,7 +227,7 @@ Storehouse.prototype.Fetch = function( request, response ) {
 
     var filename = path.normalize( self.options.directory + path.sep + request.body.path );
     var directory = path.dirname( filename );
-    
+
     async.series( [
         // check if the file exists and if we can overwrite it if it does
         function( callback ) {
@@ -237,11 +237,11 @@ Storehouse.prototype.Fetch = function( request, response ) {
                     callback( { error: 'file exists', message: 'The path you are trying to fetch to already exists and cannot be overwritten.', code: 400 } );
                     return;
                 }
-            
+
                 callback();
             } );
         },
-        
+
         // create the necessary directory structure
         function( callback ) {
             fs.mkdir( directory, '0755', true, function( error ) {
@@ -250,11 +250,11 @@ Storehouse.prototype.Fetch = function( request, response ) {
                     callback( { error: 'error creating directory', message: error, code: 500 } );
                     return;
                 }
-            
+
                 callback();
             } );
         },
-        
+
         // fetch the file
         function( callback ) {
             var file = fs.createWriteStream( filename );
@@ -268,7 +268,7 @@ Storehouse.prototype.Fetch = function( request, response ) {
                 callback( error );
             } );
         },
-        
+
         // set proper permissions on the uploaded file
         function( callback ) {
             fs.chmod( filename, '0644', function( error ) {
@@ -277,18 +277,18 @@ Storehouse.prototype.Fetch = function( request, response ) {
                     callback( { error: 'error changing file permissions', message: error, code: 500 } );
                     return;
                 }
-            
+
                 callback();
             } );
         },
-        
+
     ], function( error ) {
         if ( error )
         {
             response.json( error, error.code || 500 );
             return;
         }
-        
+
         response.json( { 'path': request.body.path } );
 
         fs.stat( filename, function( error, stats ) {
@@ -302,7 +302,7 @@ Storehouse.prototype.Fetch = function( request, response ) {
                 {
                     console.error( mimeError );
                 }
-                
+
                 self.emit( 'fetched', {
                     url: request.body.url,
                     path: request.body.path,
@@ -328,7 +328,7 @@ Storehouse.prototype.listen = function( _options ) {
     var self = this;
 
     var options = extend( {}, listenDefaults, _options );
-    
+
     var app = express();
     self.attach( app );
 
@@ -347,14 +347,14 @@ Storehouse.prototype.listen = function( _options ) {
             port: options.ssl.port
         } );
     }
-    
+
     var httpServer = http.createServer( app );
 
     httpServer.listen( options.port );
 
     self.emit( 'listening', {
-        port: options.port 
+        port: options.port
     } );
-    
+
     return self;
 }

--- a/storehouse.js
+++ b/storehouse.js
@@ -79,19 +79,12 @@ Storehouse.prototype.attach = function( app ) {
         var directory = path.dirname( filename );
         var fileInfo = request.files.file;
 
-        fs.stat( filename, function( error ) {
-            if ( error )
-            {
-                console.error( error );
-            }
-
-            self.emit( 'upload-requested', {
-                path: request.body.path,
-                directory: directory,
-                filename: filename,
-                location: path.resolve( filename ),
-                type: fileInfo.type
-            } );
+        self.emit( 'upload-requested', {
+            path: request.body.path,
+            directory: directory,
+            filename: filename,
+            location: path.resolve( filename ),
+            type: fileInfo.type
         } );
 
         self.AcceptUpload( request, response, next );
@@ -101,26 +94,19 @@ Storehouse.prototype.attach = function( app ) {
         var filename = path.normalize( self.options.directory + path.sep + request.body.path );
         var directory = path.dirname( filename );
 
-        fs.stat( filename, function( error ) {
-            if ( error )
+        mimeMagic.detectFile( filename, function( mimeError, mimeType ) {
+            if ( mimeError )
             {
-                console.error( error );
+                console.error( mimeError );
             }
 
-            mimeMagic.detectFile( filename, function( mimeError, mimeType ) {
-                if ( mimeError )
-                {
-                    console.error( mimeError );
-                }
-
-                self.emit( 'fetch-requested', {
-                    url: request.body.url,
-                    path: request.body.path,
-                    directory: directory,
-                    filename: filename,
-                    location: path.resolve( filename ),
-                    type: mimeType
-                } );
+            self.emit( 'fetch-requested', {
+                url: request.body.url,
+                path: request.body.path,
+                directory: directory,
+                filename: filename,
+                location: path.resolve( filename ),
+                type: mimeType
             } );
         } );
 

--- a/storehouse.js
+++ b/storehouse.js
@@ -84,7 +84,8 @@ Storehouse.prototype.attach = function( app ) {
             directory: directory,
             filename: filename,
             location: path.resolve( filename ),
-            type: fileInfo.type
+            type: fileInfo.mimetype,
+            encoding: fileInfo.encoding
         } );
 
         self.AcceptUpload( request, response, next );
@@ -213,7 +214,8 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
                 filename: filename,
                 location: path.resolve( filename ),
                 size: stats ? stats.size : -1,
-                type: fileInfo.type
+                type: fileInfo.mimetype,
+                encoding: fileInfo.encoding
             } );
         } );
     } );

--- a/storehouse.js
+++ b/storehouse.js
@@ -32,8 +32,7 @@ function Storehouse( _options ) {
 
     self.options = extend( {}, defaults, _options );
 
-    if ( !self.options.secret )
-    {
+    if ( !self.options.secret ) {
         throw 'You must specify a secret.';
     }
 }
@@ -43,8 +42,7 @@ util.inherits( Storehouse, EventEmitter );
 Storehouse.prototype.attach = function( app ) {
     var self = this;
 
-    if ( self.options.allowDownload )
-    {
+    if ( self.options.allowDownload ) {
         var staticMiddleware = express.static( self.options.directory[ 0 ] == path.sep ? self.options.directory : ( process.cwd() + path.sep + self.options.directory ) );
 
         app.use( self.options.downloadPrefix, staticMiddleware );
@@ -54,13 +52,11 @@ Storehouse.prototype.attach = function( app ) {
         response.header( 'Access-Control-Allow-Origin', self.options.origin );
         response.header( 'Access-Control-Allow-Methods', 'POST' );
 
-        if ( !!request.headers[ 'access-control-request-headers' ] )
-        {
+        if ( !!request.headers[ 'access-control-request-headers' ] ) {
             response.header( 'Access-Control-Allow-Headers', request.headers[ 'access-control-request-headers' ] );
         }
 
-        if ( request.method === 'OPTIONS' )
-        {
+        if ( request.method === 'OPTIONS' ) {
             response.send( 200 );
             return;
         }
@@ -68,8 +64,7 @@ Storehouse.prototype.attach = function( app ) {
         next();
     }
 
-    if ( self.options.cors )
-    {
+    if ( self.options.cors ) {
         app.all( self.options.uploadURL, AllowCORS );
         app.all( self.options.fetchURL, AllowCORS );
     }
@@ -110,30 +105,38 @@ Storehouse.prototype.attach = function( app ) {
 Storehouse.prototype.AcceptUpload = function( request, response ) {
     var self = this;
 
-    if ( !request.files || !request.files.file )
-    {
-        response.json( { error: 'file missing', message: 'No file present in request.' }, 400 );
+    if ( !request.files || !request.files.file ) {
+        response.json( {
+            error: 'file missing',
+            message: 'No file present in request.'
+        }, 400 );
         return;
     }
 
-    if ( !request.body.path )
-    {
-        response.json( { error: 'path missing', message: 'No path specified in request.' }, 400 );
+    if ( !request.body.path ) {
+        response.json( {
+            error: 'path missing',
+            message: 'No path specified in request.'
+        }, 400 );
         return;
     }
 
-    if ( !request.body.signature )
-    {
-        response.json( { error: 'signature missing', message: 'No signature specified in request.' }, 400 );
+    if ( !request.body.signature ) {
+        response.json( {
+            error: 'signature missing',
+            message: 'No signature specified in request.'
+        }, 400 );
         return;
     }
 
     var fileInfo = request.files.file;
     var signature = crypto.createHash( 'sha1' ).update( request.body.path + fileInfo.mimetype + self.options.secret ).digest( 'hex' );
 
-    if ( signature != request.body.signature )
-    {
-        response.json( { error: 'invalid signature', message: 'Signature for this upload is invalid.' }, 400 );
+    if ( signature != request.body.signature ) {
+        response.json( {
+            error: 'invalid signature',
+            message: 'Signature for this upload is invalid.'
+        }, 400 );
         return;
     }
 
@@ -144,9 +147,12 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
         // check if the file exists and if we can overwrite it if it does
         function( callback ) {
             fs.exists( filename, function( exists ) {
-                if ( exists && !self.options.overwrite )
-                {
-                    callback( { error: 'file exists', message: 'The file you are trying to upload already exists and cannot be overwritten.', code: 400 } );
+                if ( exists && !self.options.overwrite ) {
+                    callback( {
+                        error: 'file exists',
+                        message: 'The file you are trying to upload already exists and cannot be overwritten.',
+                        code: 400
+                    } );
                     return;
                 }
 
@@ -157,9 +163,12 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
         // create the necessary directory structure
         function( callback ) {
             fs.mkdir( directory, '0755', true, function( error ) {
-                if ( error )
-                {
-                    callback( { error: 'error creating directory', message: error, code: 500 } );
+                if ( error ) {
+                    callback( {
+                        error: 'error creating directory',
+                        message: error,
+                        code: 500
+                    } );
                     return;
                 }
 
@@ -170,9 +179,12 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
         // move the uploaded file from its temp location to the target location
         function( callback ) {
             fs.rename( fileInfo.path, filename, function( error ) {
-                if ( error )
-                {
-                    callback( { error: 'error moving file', message: error, code: 500 } );
+                if ( error ) {
+                    callback( {
+                        error: 'error moving file',
+                        message: error,
+                        code: 500
+                    } );
                     return;
                 }
 
@@ -183,9 +195,12 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
         // set proper permissions on the uploaded file
         function( callback ) {
             fs.chmod( filename, '0644', function( error ) {
-                if ( error )
-                {
-                    callback( { error: 'error changing file permissions', message: error, code: 500 } );
+                if ( error ) {
+                    callback( {
+                        error: 'error changing file permissions',
+                        message: error,
+                        code: 500
+                    } );
                     return;
                 }
 
@@ -194,17 +209,17 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
         }
 
     ], function( error ) {
-        if ( error )
-        {
+        if ( error ) {
             response.json( error, error.code || 500 );
             return;
         }
 
-        response.json( { 'path': request.body.path } );
+        response.json( {
+            'path': request.body.path
+        } );
 
         fs.stat( filename, function( error, stats ) {
-            if ( error )
-            {
+            if ( error ) {
                 console.error( error );
             }
 
@@ -224,29 +239,37 @@ Storehouse.prototype.AcceptUpload = function( request, response ) {
 Storehouse.prototype.Fetch = function( request, response ) {
     var self = this;
 
-    if ( !request.body.url )
-    {
-        response.json( { error: 'url missing', message: 'No url to fetch specified in request.' }, 400 );
+    if ( !request.body.url ) {
+        response.json( {
+            error: 'url missing',
+            message: 'No url to fetch specified in request.'
+        }, 400 );
         return;
     }
 
-    if ( !request.body.path )
-    {
-        response.json( { error: 'path missing', message: 'No path specified in request.' }, 400 );
+    if ( !request.body.path ) {
+        response.json( {
+            error: 'path missing',
+            message: 'No path specified in request.'
+        }, 400 );
         return;
     }
 
-    if ( !request.body.signature )
-    {
-        response.json( { error: 'signature missing', message: 'No signature specified in request.' }, 400 );
+    if ( !request.body.signature ) {
+        response.json( {
+            error: 'signature missing',
+            message: 'No signature specified in request.'
+        }, 400 );
         return;
     }
 
     var signature = crypto.createHash( 'sha1' ).update( request.body.url + request.body.path + self.options.secret ).digest( 'hex' );
 
-    if ( signature != request.body.signature )
-    {
-        response.json( { error: 'invalid signature', message: 'Signature for this fetch request is invalid.' }, 400 );
+    if ( signature != request.body.signature ) {
+        response.json( {
+            error: 'invalid signature',
+            message: 'Signature for this fetch request is invalid.'
+        }, 400 );
         return;
     }
 
@@ -257,9 +280,12 @@ Storehouse.prototype.Fetch = function( request, response ) {
         // check if the file exists and if we can overwrite it if it does
         function( callback ) {
             fs.exists( filename, function( exists ) {
-                if ( exists && !self.options.overwrite )
-                {
-                    callback( { error: 'file exists', message: 'The path you are trying to fetch to already exists and cannot be overwritten.', code: 400 } );
+                if ( exists && !self.options.overwrite ) {
+                    callback( {
+                        error: 'file exists',
+                        message: 'The path you are trying to fetch to already exists and cannot be overwritten.',
+                        code: 400
+                    } );
                     return;
                 }
 
@@ -270,9 +296,12 @@ Storehouse.prototype.Fetch = function( request, response ) {
         // create the necessary directory structure
         function( callback ) {
             fs.mkdir( directory, '0755', true, function( error ) {
-                if ( error )
-                {
-                    callback( { error: 'error creating directory', message: error, code: 500 } );
+                if ( error ) {
+                    callback( {
+                        error: 'error creating directory',
+                        message: error,
+                        code: 500
+                    } );
                     return;
                 }
 
@@ -297,9 +326,12 @@ Storehouse.prototype.Fetch = function( request, response ) {
         // set proper permissions on the uploaded file
         function( callback ) {
             fs.chmod( filename, '0644', function( error ) {
-                if ( error )
-                {
-                    callback( { error: 'error changing file permissions', message: error, code: 500 } );
+                if ( error ) {
+                    callback( {
+                        error: 'error changing file permissions',
+                        message: error,
+                        code: 500
+                    } );
                     return;
                 }
 
@@ -308,23 +340,22 @@ Storehouse.prototype.Fetch = function( request, response ) {
         },
 
     ], function( error ) {
-        if ( error )
-        {
+        if ( error ) {
             response.json( error, error.code || 500 );
             return;
         }
 
-        response.json( { 'path': request.body.path } );
+        response.json( {
+            'path': request.body.path
+        } );
 
         fs.stat( filename, function( error, stats ) {
-            if ( error )
-            {
+            if ( error ) {
                 console.error( error );
             }
 
             mimeMagic.detectFile( filename, function( mimeError, mimeType ) {
-                if ( mimeError )
-                {
+                if ( mimeError ) {
                     console.error( mimeError );
                 }
 
@@ -357,9 +388,8 @@ Storehouse.prototype.listen = function( _options ) {
     var app = express();
     self.attach( app );
 
-    if ( options.ssl && options.ssl.key && options.ssl.cert )
-    {
-        var httpsServer = https.createServer({
+    if ( options.ssl && options.ssl.key && options.ssl.cert ) {
+        var httpsServer = https.createServer( {
             key: fs.readFileSync( options.ssl.key ),
             cert: fs.readFileSync( options.ssl.cert ),
             ca: options.ssl.ca || []


### PR DESCRIPTION
- Adds two listeners/emitters to console log all `upload` and `url-fetching` requests
  - Now, should an upload or url-fetch fail, storehouse.log will contain an entry corresponding to the upload/fetch attempt
- Adds timestamp to Storehouse's initial status message on startup
- Changed `request.files['file']` to dot notation: `request.files.file`
- Adds some missing semi-colons
- Removes some whitespace

Closes honeinc/node-storehouse#1